### PR TITLE
fix billing invocations calculation

### DIFF
--- a/billing/handler_test.go
+++ b/billing/handler_test.go
@@ -75,28 +75,19 @@ func Test_calculateInvocationsCost_whenRounded(t *testing.T) {
 	}
 }
 
-func Test_calculateRemainingInvocations_whenExact(t *testing.T) {
-	balance := uint64(1)
+func Test_NewFunctionBalance_whenBalanceZero(t *testing.T) {
+	credit := uint64(0)
+	invocations := uint64(5)
 	costPerUnitInvocations := uint64(10)
-	unitInvocations := uint64(1000)
+	unitInvocations := uint64(100)
+	bonusInvocations := uint64(50)
 
-	expected := uint64(100)
-
-	got := calculateRemainingInvocations(balance, costPerUnitInvocations, unitInvocations)
-
-	if expected != got {
-		t.Errorf("Expected: %d, got: %d", expected, got)
+	expected := FunctionBalance{
+		Balance:     0,
+		Invocations: 45,
 	}
-}
 
-func Test_calculateRemainingInvocations_whenRounded(t *testing.T) {
-	balance := uint64(1)
-	costPerUnitInvocations := uint64(10)
-	unitInvocations := uint64(1)
-
-	expected := uint64(0)
-
-	got := calculateRemainingInvocations(balance, costPerUnitInvocations, unitInvocations)
+	got := NewFunctionBalance(credit, invocations, costPerUnitInvocations, unitInvocations, bonusInvocations)
 
 	if expected != got {
 		t.Errorf("Expected: %d, got: %d", expected, got)
@@ -112,7 +103,7 @@ func Test_NewFunctionBalance_whenBalancePositive(t *testing.T) {
 
 	expected := FunctionBalance{
 		Balance:     99,
-		Invocations: 9950,
+		Invocations: 9850,
 	}
 
 	got := NewFunctionBalance(credit, invocations, costPerUnitInvocations, unitInvocations, bonusInvocations)


### PR DESCRIPTION
If balance is zero, invocations should be deducted from remaining invocations.